### PR TITLE
Add `amd` property to `define`.

### DIFF
--- a/lib/bdload-so.js
+++ b/lib/bdload-so.js
@@ -629,7 +629,7 @@
 
 	// in node |this| is the actual global object and global is module.exports
 	// in the browser, |this| and global are the same object
-	this.define = global.define = function(
+	var define = this.define = global.define = function(
 		deps,   //(array of commonjs.moduleId, optional)
 		factory	//(any)
 	){
@@ -639,5 +639,6 @@
 		}
 		defArgs = [deps, factory];
 	};
+	define.amd = { plugins: true };
 })(this);
 // Copyright (c) 2008-2012, Rawld Gill and ALTOVISO LLC (www.altoviso.com). Use, modification, and distribution subject to terms of license.


### PR DESCRIPTION
Some libraries out there (like when.js and has.js) are actually checking for `define.amd`. This adds that property with the `plugins` property set to `true`.
